### PR TITLE
Skip profiling if request uri does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function() {
     name: 'http',
     handler: function(req, res, next) {
       http.request = !req.miniprofiler || !req.miniprofiler.enabled ? httpRequest : function(options, callback) {
-        if (!req.miniprofiler) {
+        if (!req.miniprofiler || !options.uri) {
           return httpRequest.call(http, options, callback);
         }
 


### PR DESCRIPTION
We are seeing errors with some requests and it seems related to newrelic. The call to `url.format` fails if null or undefined is passed to it. This check should prevent that from happening.
